### PR TITLE
Add multi-tenancy support with org_id

### DIFF
--- a/db/migrations/0004_orgs_and_fk.sql
+++ b/db/migrations/0004_orgs_and_fk.sql
@@ -1,0 +1,25 @@
+-- 0004_orgs_and_fk.sql
+
+-- ORGANIZATIONS ---------------------------------------------------
+CREATE TABLE IF NOT EXISTS organizations (
+  id         BIGSERIAL PRIMARY KEY,
+  name       TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Add org_id column to existing tables (idempotent, with default tenant = 1)
+ALTER TABLE sites     ADD COLUMN IF NOT EXISTS org_id BIGINT NOT NULL DEFAULT 1;
+ALTER TABLE vendors   ADD COLUMN IF NOT EXISTS org_id BIGINT NOT NULL DEFAULT 1;
+ALTER TABLE projects  ADD COLUMN IF NOT EXISTS org_id BIGINT NOT NULL DEFAULT 1;
+ALTER TABLE inventory ADD COLUMN IF NOT EXISTS org_id BIGINT NOT NULL DEFAULT 1;
+
+-- Indexes for org_id lookups
+CREATE INDEX IF NOT EXISTS idx_sites_org_id    ON sites(org_id, id);
+CREATE INDEX IF NOT EXISTS idx_vendors_org_id  ON vendors(org_id, id);
+CREATE INDEX IF NOT EXISTS idx_projects_org_id ON projects(org_id, id);
+CREATE INDEX IF NOT EXISTS idx_items_org_id    ON inventory(org_id, id);
+
+-- Per-organization uniqueness for project code
+CREATE UNIQUE INDEX IF NOT EXISTS uq_projects_org_code ON projects(org_id, code);
+


### PR DESCRIPTION
Add multi-tenancy support by introducing an `organizations` table and `org_id` columns to core entities.

---
<a href="https://cursor.com/background-agent?bcId=bc-e012e4a6-8043-4b7d-abde-24341edf5f05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e012e4a6-8043-4b7d-abde-24341edf5f05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

